### PR TITLE
Fix "store" is not defined in sharedListeners

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ kea({
     [actions.openUrl]: ({ url }, breakpoint, action) => { actions.urlOpened(url) },
     [LOCATION_CHANGE]: [
       (payload, breakpoint, action) => { store.dispatch(...) },
-      sharedListenres.otherListeForTheSameAction
+      sharedListeners.otherListeForTheSameAction
     ]
   })
 })
@@ -98,7 +98,17 @@ export default {
         return
       }
 
-      const newSharedListeners = typeof input.sharedListeners === 'function' ? input.sharedListeners(logic) : input.sharedListeners
+      const fakeLogic = {
+        ...logic
+      }
+
+      Object.defineProperty(fakeLogic, 'store', {
+        get () {
+          return getContext().store
+        }
+      })
+
+      const newSharedListeners = typeof input.sharedListeners === 'function' ? input.sharedListeners(fakeLogic) : input.sharedListeners
 
       logic.sharedListeners = {
         ...(logic.sharedListeners || {}),


### PR DESCRIPTION
Due to the sample usage in README, I thought `store` should be available in `sharedListeners` as well, but actually it was not.
So I just copied the code snippet from `listeners` to `sharedListeners` to fix the issue.